### PR TITLE
Add dependency submission job to Android workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,3 +38,20 @@ jobs:
       with:
         name: my-app-debug
         path: app/build/outputs/apk/debug/app-debug.apk
+
+  dependency-submission:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce a dependency-submission job in the Android workflow that checks out the code, sets up JDK 17, and runs the Gradle dependency submission action.