### PR TITLE
Add dependency submission job to Android workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -23,7 +22,7 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-      
+
     - name: Restore Google Services JSON
       env:
         GOOGLE_SERVICES_SECRET: ${{ secrets.GOOGLE_SERVICES_JSON }}
@@ -38,3 +37,20 @@ jobs:
       with:
         name: my-app-debug
         path: app/build/outputs/apk/debug/app-debug.apk
+
+  dependency-submission:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0


### PR DESCRIPTION
Added a new job for dependency submission with JDK 17 setup.

## Summary by Sourcery

CI:
- Introduce a new dependency-submission job in the Android workflow that checks out the code, sets up JDK 17, and submits the Gradle dependency graph.